### PR TITLE
🛠️ Insert time range for top items

### DIFF
--- a/api/quizzify/crud/albums.py
+++ b/api/quizzify/crud/albums.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from psycopg2 import sql
 
 from quizzify.db.query_executor import QueryExecutor
-from quizzify.utils.schemas import Album
+from quizzify.utils.schemas import Album, TimeRange
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -364,6 +364,7 @@ def insert_album_artist(
 def insert_top_album_user(
     album_id: str,
     user_id: str,
+    time_range: TimeRange,
 ):
     """Insert user as having listened to an album.
 
@@ -373,16 +374,19 @@ def insert_top_album_user(
         The album's ID.
     user_id : str
         The user's ID.
+    time_range : str
+        The time range for the top albums.
     """
     query = sql.SQL(
         "INSERT INTO top_albums "
-        "(album_id, user_id) "
+        "(album_id, user_id, time_range, time_date) "
         "VALUES "
-        "(%(album_id)s, %(user_id)s);"
+        "(%(album_id)s, %(user_id)s, %(time_range)s, CURRENT_DATE);"
     )
     variables = {
         "album_id": album_id,
         "user_id": user_id,
+        "time_range": time_range,
     }
     with QueryExecutor() as executor:
         executor.execute(query, variables)

--- a/api/quizzify/crud/artists.py
+++ b/api/quizzify/crud/artists.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from psycopg2 import sql
 
 from quizzify.db.query_executor import QueryExecutor
-from quizzify.utils.schemas import Artist
+from quizzify.utils.schemas import Artist, TimeRange
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -379,6 +379,7 @@ def insert_artist(
 def insert_top_artist_user(
     artist_id: str,
     user_id: str,
+    time_range: TimeRange,
 ):
     """Insert user as having listened to an artist.
 
@@ -391,13 +392,14 @@ def insert_top_artist_user(
     """
     query = sql.SQL(
         "INSERT INTO top_artists "
-        "(artist_id, user_id) "
+        "(artist_id, user_id, time_range, time_date) "
         "VALUES "
-        "(%(artist_id)s, %(user_id)s);"
+        "(%(artist_id)s, %(user_id)s, %(time_range)s, CURRENT_DATE);"
     )
     variables = {
         "artist_id": artist_id,
         "user_id": user_id,
+        "time_range": time_range,
     }
     with QueryExecutor() as executor:
         executor.execute(query, variables)

--- a/api/quizzify/crud/songs.py
+++ b/api/quizzify/crud/songs.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from psycopg2 import sql
 
 from quizzify.db.query_executor import QueryExecutor
-from quizzify.utils.schemas import Song
+from quizzify.utils.schemas import Song, TimeRange
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -170,6 +170,7 @@ def get_top_songs_ids(user_id: str):
 def insert_top_song_user(
     song_id: str,
     user_id: str,
+    time_range: TimeRange,
 ):
     """Insert user as having listened to a song.
 
@@ -182,13 +183,14 @@ def insert_top_song_user(
     """
     query = sql.SQL(
         "INSERT INTO top_songs "
-        "(song_id, user_id) "
+        "(song_id, user_id, time_range, time_date) "
         "VALUES "
-        "(%(song_id)s, %(user_id)s);"
+        "(%(song_id)s, %(user_id)s, %(time_range)s, CURRENT_DATE);"
     )
     variables = {
         "song_id": song_id,
         "user_id": user_id,
+        "time_range": time_range,
     }
     with QueryExecutor() as executor:
         executor.execute(query, variables)

--- a/api/quizzify/routers/artists/service.py
+++ b/api/quizzify/routers/artists/service.py
@@ -100,6 +100,7 @@ def insert_top_artists(
         crud.insert_top_artist_user(
             artist_id=current_artist_id,
             user_id=user_id,
+            time_range=time_range,
         )
 
         # fetch related artists from LastFM

--- a/api/quizzify/routers/songs/service.py
+++ b/api/quizzify/routers/songs/service.py
@@ -108,6 +108,7 @@ def insert_top_songs(
                 crud_albums.insert_top_album_user(
                     album_id=current_album_id,
                     user_id=user_id,
+                    time_range=time_range,
                 )
 
                 # insert song info into the database if it is not already there
@@ -131,6 +132,7 @@ def insert_top_songs(
                 crud_songs.insert_top_song_user(
                     song_id=current_song_id,
                     user_id=user_id,
+                    time_range=time_range,
                 )
 
                 # create a dictionary with the song, artist and album details

--- a/api/tests/quizzify/crud/test_albums.py
+++ b/api/tests/quizzify/crud/test_albums.py
@@ -226,7 +226,11 @@ class TestCrudAlbums(unittest.TestCase):
         album_id = "1uROBP2G4MP0O4w1v5Cpbg"
 
         # When
-        crud_albums.insert_top_album_user(user_id=user_id, album_id=album_id)
+        crud_albums.insert_top_album_user(
+            user_id=user_id,
+            album_id=album_id,
+            time_range="short_term",
+        )
 
         # Then - check if the album was inserted
         result = crud_albums.get_top_albums_id(album_id=album_id)

--- a/api/tests/quizzify/crud/test_artists.py
+++ b/api/tests/quizzify/crud/test_artists.py
@@ -193,7 +193,11 @@ class TestCrudArtists(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
         # When - insert a new artist as top artist for the user
-        crud_artists.insert_top_artist_user(artist_id, user_id)
+        crud_artists.insert_top_artist_user(
+            artist_id=artist_id,
+            user_id=user_id,
+            time_range="short_term",
+        )
 
         # Then - check if the artist was inserted
         result = crud_artists.get_top_artists_ids(user_id=user_id)

--- a/api/tests/quizzify/crud/test_songs.py
+++ b/api/tests/quizzify/crud/test_songs.py
@@ -99,7 +99,11 @@ class TestCrudSong(unittest.TestCase):
         self.assertEqual(len(result), 1)
 
         # When - insert a new song as top song for the user
-        crud_songs.insert_top_song_user(song_id, user_id)
+        crud_songs.insert_top_song_user(
+            song_id=song_id,
+            user_id=user_id,
+            time_range="short_term",
+        )
 
         # Then - check if the song was inserted
         result = crud_songs.get_top_songs_ids(user_id=user_id)

--- a/db/init.sql
+++ b/db/init.sql
@@ -105,6 +105,8 @@ DROP TABLE IF EXISTS top_artists CASCADE;
 CREATE TABLE top_artists (
   artist_id VARCHAR(50),
   user_id VARCHAR(50),
+  time_range VARCHAR(20),
+  time_date DATE,
   FOREIGN KEY (artist_id) REFERENCES artists (id),
   FOREIGN KEY (user_id) REFERENCES users_quizzify (user_id)
 );
@@ -167,10 +169,11 @@ DROP TABLE IF EXISTS top_albums CASCADE;
 CREATE TABLE top_albums (
   album_id VARCHAR(50),
   user_id VARCHAR(50),
+  time_range VARCHAR(20),
+  time_date DATE,
   FOREIGN KEY (album_id) REFERENCES albums (id),
   FOREIGN KEY (user_id) REFERENCES users_quizzify (user_id)
 );
-
 
 ----------------------------------------------------------------------------------------
 ------------------------------------ Relation Songs ------------------------------------
@@ -214,6 +217,8 @@ DROP TABLE IF EXISTS top_songs;
 CREATE TABLE top_songs (
   song_id VARCHAR(50),
   user_id VARCHAR(50),
+  time_range VARCHAR(20),
+  time_date DATE,
   FOREIGN KEY (song_id) REFERENCES songs (id),
   FOREIGN KEY (user_id) REFERENCES users_quizzify (user_id)
 );


### PR DESCRIPTION
Inserting a time range (short, medium, and long term) for the top items (top songs, top artists, and top albums) to keep a history of the top listenings of the user. Yesterday’s short-term favourites are not the same as tomorrow’s top favourites; this enables to query the latest top items from the database.